### PR TITLE
add complete_cases_only subsetting to create_model_out_submit_tmpl().…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,10 @@ Package: hubUtils
 Title: Utility functions for Infectious Disease Modeling Hubs
 Version: 0.0.0.9011
 Authors@R: 
-    person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
-           comment = c(ORCID = "0000-0002-2378-4915"))
+    c(person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-2378-4915")),
+      person(family = "Consortium of Infectious Disease Modeling Hubs",
+           role = c("cph")))
 Description: A set of utility functions for downloading, plotting, and scoring
     forecast and truth data from Infectious Disease Modeling Hubs.
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubUtils
 Title: Utility functions for Infectious Disease Modeling Hubs
-Version: 0.0.0.9010
+Version: 0.0.0.9011
 Authors@R: 
     person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hubUtils 0.0.0.9011
+
+* Changed default behaviour of `create_model_out_submit_tmpl()`. Function now, by default, returns rows of complete cases only and the behaviour is controlled by argument `complete_cases_only`. Argument `remove_empty_cols` was also removed.
+
 # hubUtils 0.0.0.9010
 
 * **Support for Hubs using schema earlier than v2.0.0 deprecated**. Currently a warning is issued when interacting with such Hubs. Support will eventually be retired completely and errors will be produced with Hubs using older config schema.

--- a/R/create_model_out_submit_tmpl.R
+++ b/R/create_model_out_submit_tmpl.R
@@ -17,9 +17,11 @@
 #' For task IDs or output_type_ids where all values are optional, by default, columns
 #' are included as columns of `NA`s when `required_vals_only = TRUE`.
 #' When such columns exist, the function returns a tibble with zero rows, as no
-#' complete cases of combination of required values exists. To return a template of
-#' incomplete required cases, which includes `NA` columns, use ``
-#'
+#' complete cases of required value combinations exists.
+#' _(Note that determination of complete cases does excludes valid `NA`
+#' `output_type_id` values in `"mean"` and `"median"` output types)._
+#' To return a template of incomplete required cases, which includes `NA` columns, use
+#' `complete_cases_only = FALSE`.
 #'
 #' When a round is set to `round_id_from_variable: true`,
 #' the value of the task ID from which round IDs are derived (i.e. the task ID

--- a/R/create_model_out_submit_tmpl.R
+++ b/R/create_model_out_submit_tmpl.R
@@ -2,11 +2,10 @@
 #'
 #' @param hub_con A `⁠<hub_connection`>⁠ class object.
 #' @inheritParams expand_model_out_val_grid
-#' @param remove_empty_cols Logical. If `FALSE` (default) and `required_vals_only = TRUE`,
-#' task IDs or output_type IDs where all values are optional are included as
-#' columns of `NA`s.
-#' If `TRUE`, such columns are excluded from the output.
-#' Ignored when `required_vals_only = FALSE`.
+#' @param complete_cases_only Logical. If `TRUE` (default) and `required_vals_only = TRUE`,
+#' only rows with complete cases of combinations of required values are returned.
+#' If `FALSE`, rows with incomplete cases of combinations of required values
+#' are included in the output.
 #'
 #' @return a tibble template containing an expanded grid of valid task ID and
 #' output type ID value combinations for a given submission round
@@ -16,8 +15,11 @@
 #'
 #' @details
 #' For task IDs or output_type_ids where all values are optional, by default, columns
-#' are included as columns of `NA`s. To exclude them from the output use
-#' `remove_empty_cols = TRUE`.
+#' are included as columns of `NA`s when `required_vals_only = TRUE`.
+#' When such columns exist, the function returns a tibble with zero rows, as no
+#' complete cases of combination of required values exists. To return a template of
+#' incomplete required cases, which includes `NA` columns, use ``
+#'
 #'
 #' When a round is set to `round_id_from_variable: true`,
 #' the value of the task ID from which round IDs are derived (i.e. the task ID
@@ -39,7 +41,7 @@
 #'   hub_con,
 #'   round_id = "2023-01-02",
 #'   required_vals_only = TRUE,
-#'   remove_empty_cols = TRUE
+#'   complete_cases_only = FALSE
 #' )
 #' # Specifying a round in a hub with multiple rounds
 #' hub_con <- connect_hub(
@@ -54,11 +56,11 @@
 #' create_model_out_submit_tmpl(hub_con,
 #'   round_id = "2022-10-29",
 #'   required_vals_only = TRUE,
-#'   remove_empty_cols = TRUE
+#'   complete_cases_only = FALSE
 #' )
 create_model_out_submit_tmpl <- function(hub_con, config_tasks, round_id,
                                          required_vals_only = FALSE,
-                                         remove_empty_cols = FALSE) {
+                                         complete_cases_only = TRUE) {
   switch(rlang::check_exclusive(hub_con, config_tasks),
     hub_con = {
       checkmate::assert_class(hub_con, classes = "hub_connection")
@@ -80,35 +82,37 @@ create_model_out_submit_tmpl <- function(hub_con, config_tasks, round_id,
     std_colnames[names(std_colnames) != "model_id"]
   )
 
-  opt_cols <- tmpl_cols[!tmpl_cols %in% names(tmpl_df)]
+  na_cols <- tmpl_cols[!tmpl_cols %in% names(tmpl_df)]
 
-  if (length(opt_cols) > 0L) {
-    if (any(opt_cols != std_colnames["value"])) {
-      n_mt <- n_model_tasks(config_tasks, round_id)
-      message_opt_tasks(opt_cols, n_mt, remove_empty_cols)
-    }
+  tmpl_schema <- create_hub_schema(
+    config_tasks,
+    partitions = NULL,
+    r_schema = TRUE
+  )
+  convert_na_cols <- tmpl_schema[na_cols]
 
-    if (remove_empty_cols) {
-      return(tmpl_df)
-    } else {
-      tmpl_schema <- create_hub_schema(
-        config_tasks,
-        partitions = NULL,
-        r_schema = TRUE
+  tmpl_df[, na_cols] <- NA
+  tmpl_df[, names(convert_na_cols)] <- purrr::map2(
+    .x = names(convert_na_cols),
+    .y = convert_na_cols,
+    ~ get(paste0("as.", .y))(tmpl_df[[.x]])
+  )
+
+  tmpl_df <- tmpl_df[, tmpl_cols]
+
+  if (complete_cases_only) {
+    subset_complete_cases(tmpl_df)
+  } else {
+    # We only need to notify of added `NA` columns when we are not subsetting
+    # for complete cases only as `NA`s will only show up when
+    # complete_cases_only == FALSE
+    if (any(na_cols != std_colnames["value"])) {
+      message_opt_tasks(
+        na_cols, n_model_tasks(config_tasks, round_id)
       )
-      convert_opt_cols <- tmpl_schema[opt_cols]
-
-      tmpl_df[, opt_cols] <- NA
-      tmpl_df[, names(convert_opt_cols)] <- purrr::map2(
-        .x = names(convert_opt_cols),
-        .y = convert_opt_cols,
-        ~ get(paste0("as.", .y))(tmpl_df[[.x]])
-      )
-
-      tmpl_df <- tmpl_df[, tmpl_cols]
     }
+    tmpl_df
   }
-  tmpl_df
 }
 
 get_round_model_tasks <- function(config_tasks, round_id) {
@@ -137,16 +141,10 @@ get_round_task_id_names <- function(config_tasks, round_id) {
     unique()
 }
 
-message_opt_tasks <- function(opt_cols, n_mt, remove_empty_cols) {
-  if (remove_empty_cols) {
-    action <- "and std column {.val {std_colnames['value']}} not included in template."
-  } else {
-    action <- "included as all {.code NA} column{?s}."
-  }
-  opt_cols <- opt_cols[opt_cols != "value"]
-
-  msg <- c("!" = paste("{cli::qty(length(opt_cols))}Column{?s} {.val {opt_cols}}
-                       whose values are all optional", action))
+message_opt_tasks <- function(na_cols, n_mt, remove_empty_cols) {
+  na_cols <- na_cols[na_cols != "value"]
+  msg <- c("!" = "{cli::qty(length(na_cols))}Column{?s} {.val {na_cols}}
+           whose values are all optional included as all {.code NA} column{?s}.")
   if (n_mt > 1L) {
     msg <- c(
       msg,
@@ -160,4 +158,28 @@ message_opt_tasks <- function(opt_cols, n_mt, remove_empty_cols) {
     task ID/output_type/output_type ID value combinations."
   )
   cli::cli_bullets(msg)
+}
+
+subset_complete_cases <- function(tmpl_df) {
+
+  # get complete cases across all columns except 'value'
+  cols <- !names(tmpl_df) %in% std_colnames[c("value", "model_id")]
+  compl_cases <- stats::complete.cases(tmpl_df[, cols])
+
+  # As 'mean' and 'median' output types have valid 'NA' entries in 'output_type'
+  # column indicating that they are required, ovewrite the initial check for
+  # complete cases by performing the check again only on rows where output type is
+  # mean/median and using all columns except 'value' and 'output_type'.
+  na_output_type_idx <- which(
+    tmpl_df[[std_colnames["output_type"]]] %in% c("mean", "median")
+  )
+  cols <- !names(tmpl_df) %in% std_colnames[c(
+    "output_type_id",
+    "value",
+    "model_id"
+  )]
+  compl_cases[na_output_type_idx] <- stats::complete.cases(
+    tmpl_df[na_output_type_idx, cols]
+  )
+  tmpl_df[compl_cases, ]
 }

--- a/R/create_model_out_submit_tmpl.R
+++ b/R/create_model_out_submit_tmpl.R
@@ -141,7 +141,7 @@ get_round_task_id_names <- function(config_tasks, round_id) {
     unique()
 }
 
-message_opt_tasks <- function(na_cols, n_mt, remove_empty_cols) {
+message_opt_tasks <- function(na_cols, n_mt) {
   na_cols <- na_cols[na_cols != "value"]
   msg <- c("!" = "{cli::qty(length(na_cols))}Column{?s} {.val {na_cols}}
            whose values are all optional included as all {.code NA} column{?s}.")
@@ -166,8 +166,8 @@ subset_complete_cases <- function(tmpl_df) {
   cols <- !names(tmpl_df) %in% std_colnames[c("value", "model_id")]
   compl_cases <- stats::complete.cases(tmpl_df[, cols])
 
-  # As 'mean' and 'median' output types have valid 'NA' entries in 'output_type'
-  # column indicating that they are required, ovewrite the initial check for
+  # As 'mean' and 'median' output types have valid 'NA' entries in 'output_type_id'
+  # column when they are required, ovewrite the initial check for
   # complete cases by performing the check again only on rows where output type is
   # mean/median and using all columns except 'value' and 'output_type'.
   na_output_type_idx <- which(

--- a/man/create_model_out_submit_tmpl.Rd
+++ b/man/create_model_out_submit_tmpl.Rd
@@ -9,7 +9,7 @@ create_model_out_submit_tmpl(
   config_tasks,
   round_id,
   required_vals_only = FALSE,
-  remove_empty_cols = FALSE
+  complete_cases_only = TRUE
 )
 }
 \arguments{
@@ -28,11 +28,10 @@ contains only a single round.}
 \item{required_vals_only}{Logical. Whether to return only combinations of
 Task ID and related output type ID required values.}
 
-\item{remove_empty_cols}{Logical. If \code{FALSE} (default) and \code{required_vals_only = TRUE},
-task IDs or output_type IDs where all values are optional are included as
-columns of \code{NA}s.
-If \code{TRUE}, such columns are excluded from the output.
-Ignored when \code{required_vals_only = FALSE}.}
+\item{complete_cases_only}{Logical. If \code{TRUE} (default) and \code{required_vals_only = TRUE},
+only rows with complete cases of combinations of required values are returned.
+If \code{FALSE}, rows with incomplete cases of combinations of required values
+are included in the output.}
 }
 \value{
 a tibble template containing an expanded grid of valid task ID and
@@ -46,8 +45,10 @@ Create a model output submission file template
 }
 \details{
 For task IDs or output_type_ids where all values are optional, by default, columns
-are included as columns of \code{NA}s. To exclude them from the output use
-\code{remove_empty_cols = TRUE}.
+are included as columns of \code{NA}s when \code{required_vals_only = TRUE}.
+When such columns exist, the function returns a tibble with zero rows, as no
+complete cases of combination of required values exists. To return a template of
+incomplete required cases, which includes \code{NA} columns, use ``
 
 When a round is set to \code{round_id_from_variable: true},
 the value of the task ID from which round IDs are derived (i.e. the task ID
@@ -68,7 +69,7 @@ create_model_out_submit_tmpl(
   hub_con,
   round_id = "2023-01-02",
   required_vals_only = TRUE,
-  remove_empty_cols = TRUE
+  complete_cases_only = FALSE
 )
 # Specifying a round in a hub with multiple rounds
 hub_con <- connect_hub(
@@ -83,6 +84,6 @@ create_model_out_submit_tmpl(hub_con,
 create_model_out_submit_tmpl(hub_con,
   round_id = "2022-10-29",
   required_vals_only = TRUE,
-  remove_empty_cols = TRUE
+  complete_cases_only = FALSE
 )
 }

--- a/man/create_model_out_submit_tmpl.Rd
+++ b/man/create_model_out_submit_tmpl.Rd
@@ -47,8 +47,11 @@ Create a model output submission file template
 For task IDs or output_type_ids where all values are optional, by default, columns
 are included as columns of \code{NA}s when \code{required_vals_only = TRUE}.
 When such columns exist, the function returns a tibble with zero rows, as no
-complete cases of combination of required values exists. To return a template of
-incomplete required cases, which includes \code{NA} columns, use ``
+complete cases of required value combinations exists.
+\emph{(Note that determination of complete cases does excludes valid \code{NA}
+\code{output_type_id} values in \code{"mean"} and \code{"median"} output types).}
+To return a template of incomplete required cases, which includes \code{NA} columns, use
+\code{complete_cases_only = FALSE}.
 
 When a round is set to \code{round_id_from_variable: true},
 the value of the task ID from which round IDs are derived (i.e. the task ID

--- a/tests/testthat/_snaps/create_model_out_submit_tmpl.md
+++ b/tests/testthat/_snaps/create_model_out_submit_tmpl.md
@@ -51,20 +51,15 @@
     Code
       str(create_model_out_submit_tmpl(hub_con, round_id = "2023-01-16",
         required_vals_only = TRUE))
-    Message <cliMessage>
-      ! Column "target" whose values are all optional included as all `NA` column.
-      ! Round contains more than one modeling task (2)
-      i See Hub's 'tasks.json' file or <hub_connection> attribute "config_tasks" for
-        details of optional task ID/output_type/output_type ID value combinations.
     Output
-      tibble [29 x 7] (S3: tbl_df/tbl/data.frame)
-       $ forecast_date : chr [1:29] "2023-01-16" "2023-01-16" "2023-01-16" "2023-01-16" ...
-       $ target        : chr [1:29] NA NA NA NA ...
-       $ horizon       : int [1:29] 2 2 2 2 2 2 2 2 2 2 ...
-       $ location      : chr [1:29] "US" "US" "US" "US" ...
-       $ output_type   : chr [1:29] "pmf" "pmf" "pmf" "pmf" ...
-       $ output_type_id: chr [1:29] "large_decrease" "decrease" "stable" "increase" ...
-       $ value         : num [1:29] NA NA NA NA NA NA NA NA NA NA ...
+      tibble [0 x 7] (S3: tbl_df/tbl/data.frame)
+       $ forecast_date : chr(0) 
+       $ target        : chr(0) 
+       $ horizon       : int(0) 
+       $ location      : chr(0) 
+       $ output_type   : chr(0) 
+       $ output_type_id: chr(0) 
+       $ value         : num(0) 
        - attr(*, "out.attrs")=List of 2
         ..$ dim     : Named int [1:5] 1 1 1 1 5
         .. ..- attr(*, "names")= chr [1:5] "forecast_date" "horizon" "location" "output_type" ...
@@ -79,20 +74,21 @@
 
     Code
       str(create_model_out_submit_tmpl(hub_con, round_id = "2023-01-16",
-        required_vals_only = TRUE, remove_empty_cols = TRUE))
+        required_vals_only = TRUE, complete_cases_only = FALSE))
     Message <cliMessage>
-      ! Column "target" whose values are all optional and std column "value" not
-        included in template.
+      ! Column "target" whose values are all optional included as all `NA` column.
       ! Round contains more than one modeling task (2)
       i See Hub's 'tasks.json' file or <hub_connection> attribute "config_tasks" for
         details of optional task ID/output_type/output_type ID value combinations.
     Output
-      tibble [29 x 5] (S3: tbl_df/tbl/data.frame)
+      tibble [29 x 7] (S3: tbl_df/tbl/data.frame)
        $ forecast_date : chr [1:29] "2023-01-16" "2023-01-16" "2023-01-16" "2023-01-16" ...
+       $ target        : chr [1:29] NA NA NA NA ...
        $ horizon       : int [1:29] 2 2 2 2 2 2 2 2 2 2 ...
        $ location      : chr [1:29] "US" "US" "US" "US" ...
        $ output_type   : chr [1:29] "pmf" "pmf" "pmf" "pmf" ...
        $ output_type_id: chr [1:29] "large_decrease" "decrease" "stable" "increase" ...
+       $ value         : num [1:29] NA NA NA NA NA NA NA NA NA NA ...
        - attr(*, "out.attrs")=List of 2
         ..$ dim     : Named int [1:5] 1 1 1 1 5
         .. ..- attr(*, "names")= chr [1:5] "forecast_date" "horizon" "location" "output_type" ...
@@ -121,7 +117,7 @@
 
     Code
       str(create_model_out_submit_tmpl(hub_con, round_id = "2022-10-01",
-        required_vals_only = TRUE))
+        required_vals_only = TRUE, complete_cases_only = FALSE))
     Message <cliMessage>
       ! Column "location" whose values are all optional included as all `NA` column.
       i See Hub's 'tasks.json' file or <hub_connection> attribute "config_tasks" for
@@ -140,7 +136,7 @@
 
     Code
       str(create_model_out_submit_tmpl(hub_con, round_id = "2022-10-29",
-        required_vals_only = TRUE))
+        required_vals_only = TRUE, complete_cases_only = FALSE))
     Message <cliMessage>
       ! Column "location" whose values are all optional included as all `NA` column.
       i See Hub's 'tasks.json' file or <hub_connection> attribute "config_tasks" for
@@ -160,20 +156,17 @@
 
     Code
       str(create_model_out_submit_tmpl(hub_con, round_id = "2022-10-29",
-        required_vals_only = TRUE, remove_empty_cols = TRUE))
-    Message <cliMessage>
-      ! Column "location" whose values are all optional and std column "value" not
-        included in template.
-      i See Hub's 'tasks.json' file or <hub_connection> attribute "config_tasks" for
-        details of optional task ID/output_type/output_type ID value combinations.
+        required_vals_only = TRUE))
     Output
-      tibble [24 x 6] (S3: tbl_df/tbl/data.frame)
-       $ origin_date   : chr [1:24] "2022-10-29" "2022-10-29" "2022-10-29" "2022-10-29" ...
-       $ target        : chr [1:24] "wk inc flu hosp" "wk inc flu hosp" "wk inc flu hosp" "wk inc flu hosp" ...
-       $ horizon       : int [1:24] 1 1 1 1 1 1 1 1 1 1 ...
-       $ age_group     : chr [1:24] "65+" "65+" "65+" "65+" ...
-       $ output_type   : chr [1:24] "mean" "quantile" "quantile" "quantile" ...
-       $ output_type_id: num [1:24] NA 0.01 0.025 0.05 0.1 0.15 0.2 0.25 0.3 0.35 ...
+      tibble [0 x 8] (S3: tbl_df/tbl/data.frame)
+       $ origin_date   : chr(0) 
+       $ target        : chr(0) 
+       $ horizon       : int(0) 
+       $ location      : chr(0) 
+       $ age_group     : chr(0) 
+       $ output_type   : chr(0) 
+       $ output_type_id: num(0) 
+       $ value         : int(0) 
 
 # create_model_out_submit_tmpl errors correctly
 

--- a/tests/testthat/test-create_model_out_submit_tmpl.R
+++ b/tests/testthat/test-create_model_out_submit_tmpl.R
@@ -34,7 +34,8 @@ test_that("create_model_out_submit_tmpl works correctly", {
             create_model_out_submit_tmpl(
                 hub_con,
                 round_id = "2022-12-19",
-                required_vals_only = TRUE
+                required_vals_only = TRUE,
+                complete_cases_only = FALSE
             )$forecast_date
         )),
         "2022-12-19"
@@ -46,7 +47,7 @@ test_that("create_model_out_submit_tmpl works correctly", {
             hub_con,
             round_id = "2023-01-16",
             required_vals_only = TRUE,
-            remove_empty_cols = TRUE
+            complete_cases_only = FALSE
         )
     ))
 
@@ -56,7 +57,7 @@ test_that("create_model_out_submit_tmpl works correctly", {
                 hub_con,
                 round_id = "2022-12-19",
                 required_vals_only = TRUE,
-                remove_empty_cols = TRUE
+                complete_cases_only = FALSE
             )$forecast_date
         )),
         "2022-12-19"
@@ -78,24 +79,25 @@ test_that("create_model_out_submit_tmpl works correctly", {
         create_model_out_submit_tmpl(
             hub_con,
             round_id = "2022-10-01",
-            required_vals_only = TRUE
+            required_vals_only = TRUE,
+            complete_cases_only = FALSE
         )
     ))
-    expect_snapshot(str(
-        create_model_out_submit_tmpl(
-            hub_con,
-            round_id = "2022-10-29",
-            required_vals_only = TRUE
-        )
-    ))
-
-
     expect_snapshot(str(
         create_model_out_submit_tmpl(
             hub_con,
             round_id = "2022-10-29",
             required_vals_only = TRUE,
-            remove_empty_cols = TRUE
+            complete_cases_only = FALSE
+        )
+    ))
+
+
+    expect_snapshot(str(
+        create_model_out_submit_tmpl(
+            hub_con,
+            round_id = "2022-10-29",
+            required_vals_only = TRUE
         )
     ))
 })

--- a/tests/testthat/test-validate-inst-hubs.R
+++ b/tests/testthat/test-validate-inst-hubs.R
@@ -1,0 +1,31 @@
+test_that("simple example hub configured correctly", {
+  expect_true(
+    all(
+      unlist(
+        suppressMessages(
+          validate_hub_config(
+            hub_path = system.file("testhubs/simple",
+              package = "hubUtils"
+            )
+          )
+        )
+      )
+    )
+  )
+})
+
+test_that("flusight example hub configured correctly", {
+    expect_true(
+        all(
+            unlist(
+                suppressMessages(
+                    validate_hub_config(
+                        hub_path = system.file("testhubs/flusight",
+                                               package = "hubUtils"
+                        )
+                    )
+                )
+            )
+        )
+    )
+})


### PR DESCRIPTION
Put this solution together quickly in response to @nickreich & @elray1 angst about the current behaviour of `create_model_out_submit_tmpl()`

(Hopefully) Resolves #90 by returning zero row tibbles by default when there is an all NA column.

Note as well that I removed the `remove_empty_cols` argument (and functionality ) all together as it did not seem to be a useful feature in any of the discussions and added significantly to the complexity of determining the function output.

One thing that could be helpful is more details in the roxygen documentation section as I'm not sure I've captured the reasoning/context behind the desired behaviour (i,e, returning zero row tibbles by default when there is an all NA column)  well enough.